### PR TITLE
Fix case where delta is greater than loop length

### DIFF
--- a/src/samplv1_sample.h
+++ b/src/samplv1_sample.h
@@ -268,7 +268,7 @@ public:
 				if (m_phase >= m_loop_phase2 - xfade1) {
 					if (//m_sample->isOver(m_index) ||
 						m_phase >= m_loop_phase2) {
-						m_phase -= m_loop_phase1;
+						m_phase -= m_loop_phase1 * std::ceil(delta/m_loop_phase1);
 						if (m_phase < m_phase0)
 							m_phase = m_phase0;
 					}
@@ -296,7 +296,7 @@ public:
 			}
 			else
 			if (m_phase >= m_loop_phase2) {
-				m_phase -= m_loop_phase1;
+				m_phase -= m_loop_phase1 * std::ceil(delta/m_loop_phase1);
 				if (m_phase < m_phase0)
 					m_phase = m_phase0;
 			}


### PR DESCRIPTION
This may happen when the loop is very short and the note pitch is very
high. In the absence of that fix the m_phase may go out of bound,
including beyond the allocated memory for the sample, producing
glitches and eventually a crash.