### PR TITLE
When compressing with gzip it encodes the current timestamp in it's file

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -163,7 +163,7 @@ install_jack:	jack
 	@$(MAKE) INSTALL_ROOT=$(DESTDIR) -f $(name_jack).mak install
 	@install -d -v -m 0755 $(DESTDIR)$(mandir)/man1
 	@install -v -m 0644 $(name)*.1 $(DESTDIR)$(mandir)/man1
-	@gzip -vf $(DESTDIR)$(mandir)/man1/$(name)*.1
+	@gzip -nvf $(DESTDIR)$(mandir)/man1/$(name)*.1
 
 
 uninstall_core:	core


### PR DESCRIPTION
header. Passing -n to gzip does not record the timestamp and makes the
man pages reproducible.

Motivation: https://reproducible-builds.org

Signed-off-by: Jelle van der Waa <jelle@archlinux.org>