### PR TITLE
Add a --client-name option to samplv1_jack

### DIFF
--- a/src/samplv1_jack.h
+++ b/src/samplv1_jack.h
@@ -43,7 +43,7 @@ class samplv1_jack : public samplv1
 {
 public:
 
-	samplv1_jack();
+	samplv1_jack(const char *client_name);
 
 	~samplv1_jack();
 
@@ -188,6 +188,7 @@ private:
 	// Instance variables.
 	QCoreApplication *m_pApp;
 	bool m_bGui;
+	QString m_client_name;
 
 	QStringList m_presets;
 


### PR DESCRIPTION
Hey Rui,

first of all thank you for all the brilliant open source software. I very much enjoyed using samplv1 and drumkitv1 on the last weekend.

Attached is a pull request that adds a new option called `--client-name` to the `samplv1_jack` program. This option is useful to me as it allows me to start multiple instances of samplv1 and automatically connect them up to other programs using the `jack_connect` tool. I tried to make the change fit in with the style of the project, but I am not quite sure about the capitalization and naming convention for members.

all the best